### PR TITLE
Make fastSpawn only run in dev, fixing mod conflicts.

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -23,6 +23,7 @@ minecraft {
 
 dependencies {
     compileOnly group:'org.spongepowered', name:'mixin', version:'0.8.5'
+    compileOnly group: 'org.ow2.asm', name: 'asm-tree', version: '9.2'
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
 }
 

--- a/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/YungsApiMixinPlugin.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/YungsApiMixinPlugin.java
@@ -1,0 +1,61 @@
+package com.yungnickyoung.minecraft.yungsapi;// Created 2022-03-04T21:09:11
+
+import com.yungnickyoung.minecraft.yungsapi.services.Services;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Disables development-only mixins to avoid unnecessary conflict with other
+ * mods, such as ServerCore.
+ *
+ * @author KJP12
+ **/
+public class YungsApiMixinPlugin implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        // no-op
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        // no-op, we have nothing to add
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // Only mixin this class in the case of a development environment.
+        // Please be careful as to which classes you call here, as there is a possibility
+        // of cascade loading Minecraft classes, *which you do not want.*
+        if ("com.yungnickyoung.minecraft.yungsapi.mixin.MinecraftServerMixin".equals(mixinClassName)) {
+            return Services.PLATFORM.isDevelopmentEnvironment();
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+        // no-op
+    }
+
+    @Override
+    public List<String> getMixins() {
+        // no-op, we have nothing to add
+        return null;
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        // no-op
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        // no-op
+    }
+}

--- a/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/mixin/MinecraftServerMixin.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/mixin/MinecraftServerMixin.java
@@ -7,12 +7,12 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(value = MinecraftServer.class, priority = 500)
 public class MinecraftServerMixin {
-    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 11, ordinal = 0), require = 0)
+    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 11, ordinal = 0))
     private static int fastSpawn(int constant) {
         return 0;
     }
 
-    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 441, ordinal = 0), require = 0)
+    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 441, ordinal = 0))
     private static int fastSpawn2(int constant) {
         return 0;
     }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/mixin/MinecraftServerMixin.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/mixin/MinecraftServerMixin.java
@@ -1,20 +1,19 @@
 package com.yungnickyoung.minecraft.yungsapi.mixin;
 
-import com.yungnickyoung.minecraft.yungsapi.services.Services;
 import net.minecraft.server.MinecraftServer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
-@Mixin(MinecraftServer.class)
+@Mixin(value = MinecraftServer.class, priority = 500)
 public class MinecraftServerMixin {
-    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 11, ordinal = 0))
+    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 11, ordinal = 0), require = 0)
     private static int fastSpawn(int constant) {
-        return Services.PLATFORM.isDevelopmentEnvironment() ? 0 : 11;
+        return 0;
     }
 
-    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 441, ordinal = 0))
+    @ModifyConstant(method = "prepareLevels", constant = @Constant(intValue = 441, ordinal = 0), require = 0)
     private static int fastSpawn2(int constant) {
-        return Services.PLATFORM.isDevelopmentEnvironment() ? 0 : 441;
+        return 0;
     }
 }

--- a/Common/src/main/resources/yungsapi.mixins.json
+++ b/Common/src/main/resources/yungsapi.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.yungnickyoung.minecraft.yungsapi.mixin",
+  "plugin": "com.yungnickyoung.minecraft.yungsapi.YungsApiMixinPlugin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "yungsapi.refmap.json",
   "mixins": [


### PR DESCRIPTION
This makes `MinecraftServerMixin` an entirely dev-only mixin.

~~Additionally, this sets the priority of the mixin to `500` and makes all the constant modifiers not required to help with conflicts in the event that any previously conflicting mods, such as ServerCore, happens to be installed at the same time.~~ This didn't work as expected; this part of the change has been reverted to hard crash instead should both be present in dev at the same time.

## Resolves
Fixes #26
Fixes Wesley1808/ServerCore#23