### PR TITLE
Fix build.gradle config assuming ossrhUsername and ossrhPassword properties exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,8 +143,8 @@ publishing {
         maven {
             url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
             credentials {
-                username ossrhUsername
-                password ossrhPassword
+                username hasProperty('ossrhUsername')?ossrhUsername:''
+                password hasProperty('ossrhPassword')?ossrhPassword:''
             }
         }
     }


### PR DESCRIPTION
It seems the build.gradle is expecting two auth properties that won't necessarily be provided from anyone just looking to build the plugin from source, so these should probably be checked for and a default set if they don't exist.

Addresses #16 