### PR TITLE
Fix importing class that doesn't exist on the server side

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/world/jigsaw/assembler/JigsawStructureAssembler.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/world/jigsaw/assembler/JigsawStructureAssembler.java
@@ -12,6 +12,7 @@ import com.yungnickyoung.minecraft.yungsapi.world.jigsaw.piece.IMaxCountJigsawPo
 import com.yungnickyoung.minecraft.yungsapi.world.jigsaw.piece.YungJigsawSinglePoolElement;
 import com.yungnickyoung.minecraft.yungsapi.world.structure.context.StructureContext;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import java.util.ArrayList;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -36,7 +37,6 @@ import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
 import net.minecraft.world.phys.AABB;
-import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.lang3.mutable.MutableObject;
 
 import java.util.Deque;
@@ -59,7 +59,7 @@ public class JigsawStructureAssembler {
      * A piece only gets added to this list when its spawn conditions have been validated to ensure
      * it should be added to the structure.
      */
-    private final List<PieceEntry> pieces = Lists.newArrayList();
+    private final List<PieceEntry> pieces = new ArrayList<>();
 
     /**
      * Queue of unprocessed pieces to be processed.


### PR DESCRIPTION
When doing some experimentation locally I ran into a crash server side that seems to have been caused by https://github.com/YUNG-GANG/YUNGs-API/commit/2b5031fdb575467b0fb721a7216da598d734971f changing the import for creating a new array list from `com.google.common.collect.Lists` to `org.apache.commons.compress.utils.Lists`. The latter of these two is not present on the server side (though it seems to be present client side).

As nowhere else in this project seems to make use of google lists and instead just creates the array lists normally I decided rather than just reversing the import change to instead also switch it to just creating the array list directly.