### PR TITLE
Replace Mth.fastInvSqrt(Deprecated) with Mth.invSqrt

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/world/structure/terrainadaptation/EnhancedTerrainAdaptation.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/world/structure/terrainadaptation/EnhancedTerrainAdaptation.java
@@ -140,7 +140,7 @@ public abstract class EnhancedTerrainAdaptation {
              * If we are below the beard base (i.e. yDistanceToBeardBase is negative),
              * then the multiplier is positive, and therefore contributes to solid terrain.
              */
-            double multiplier = -actualYDistanceToAdjustedBottom * Mth.fastInvSqrt(squaredDistance / 2.0) / 2.0;
+            double multiplier = -actualYDistanceToAdjustedBottom * Mth.invSqrt(squaredDistance / 2.0) / 2.0;
             if (multiplier > 0 && !this.beards()) return 0;
             if (multiplier < 0 && !this.carves()) return 0;
             return multiplier * kernelValue;


### PR DESCRIPTION
Since Mojang added joml in 1.19.4 this method has been deprecated and replaced with invSqrt which calls org.joml.Math#invsqrt which is the correct way going forward as mojang moves to use only joml.