### PR TITLE
Update to 26.1.2, allow proper usage in dependency substitution

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -45,3 +45,13 @@ artifacts {
     commonResources sourceSets.main.resources.sourceDirectories.singleFile
     commonGeneratedResources sourceSets.generated.resources.sourceDirectories.singleFile
 }
+
+// Implement mcgradleconventions loader attribute
+def loaderAttribute = Attribute.of('io.github.mcgradleconventions.loader', String)
+['apiElements', 'runtimeElements', 'sourcesElements', 'javadocElements'].each { variant ->
+    configurations.named("$variant") {
+        attributes {
+            attribute(loaderAttribute, 'common')
+        }
+    }
+}

--- a/NeoForge/build.gradle
+++ b/NeoForge/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'multiloader-loader'
-    id 'net.neoforged.gradle.userdev' version '7.1.21'
+    id 'net.neoforged.gradle.userdev' version '7.1.36'
     id 'net.darkhax.curseforgegradle'
     id 'com.modrinth.minotaur'
 }

--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 base {
-    archivesName = "${mod_name}"
-    version = "${mc_version}-${project.name}-${project.version}"
+    archivesName = "${mod_name}-${project.name}"
+    version = "${mc_version}-${project.version}"
 }
 
 group = maven_group
@@ -41,19 +41,6 @@ repositories {
     maven {
         name = 'BlameJared'
         url = 'https://maven.blamejared.com'
-    }
-}
-
-// Declare capabilities on the outgoing configurations.
-// Read more about capabilities here: https://docs.gradle.org/current/userguide/component_capabilities.html#sec:declaring-additional-capabilities-for-a-local-component
-['apiElements', 'runtimeElements', 'sourcesElements', 'javadocElements'].each { variant ->
-    configurations."$variant".outgoing {
-        capability("$group:${base.archivesName.get()}:$version")
-        capability("$group:$mod_id-${project.name}-${mc_version}:$version")
-        capability("$group:$mod_id:$version")
-    }
-    publishing.publications.configureEach {
-        suppressPomMetadataWarningsFor(variant)
     }
 }
 

--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -16,8 +16,9 @@ configurations {
 
 dependencies {
     compileOnly(project(':Common')) {
-        capabilities {
-            requireCapability "$group:$mod_id"
+        def loaderAttribute = Attribute.of('io.github.mcgradleconventions.loader', String)
+        attributes {
+            attribute(loaderAttribute, 'common')
         }
     }
     commonJava project(path: ':Common', configuration: 'commonJava')

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,25 +11,25 @@ mod_description=API Library for YUNG's minecraft mods.
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.yungsapi
-mc_version=26.1.1
-mc_version_range=[26.1,)
-mc_version_range_fabric=>=26.1
+mc_version=26.1.2
+mc_version_range=[26.1,26.2)
+mc_version_range_fabric=~26.1
 
 # CurseForge/Modrinth Publishing
 cursegradle_version=1.1.24
-compatible_versions=1.21.10
+compatible_versions=26.1,26.1.1,26.1.2
 curseforge_project_id_fabric=421649
 curseforge_project_id_neoforge=421850
 modrinth_project_id=Ua7DFN59
 debug_publish=true
 
 # Fabric
-fabric_version=0.145.3
+fabric_version=0.150.0
 fabric_loader_version=0.18.6
 
 # NeoForge
-neoforge_version=26.1.1.1-beta
-neoforge_version_range=[26.1.1.1-beta,)
+neoforge_version=26.1.2.70-beta
+neoforge_version_range=[26.1.2.70-beta,)
 neoforge_loader_version_range=[4,)
 
 # Credentials for publishing. Gets overwritten with global gradle.properties.


### PR DESCRIPTION
Slight breaking change, makes YUNG's API follow the formatting of `ProjectName-Loader:MCVersion-Version` rather than `ProjectName:MCVersion-Loader-Version`. This is intended so unpublished builds of YUNG's API can be used in dependency substitution like so:

`settings.gradle`
```groovy
if (file("yungsapi").exists()) {
    includeBuild(".")
    includeBuild("yungsapi") {
        dependencySubstitution {
            substitute(module("com.yungnickyoung.minecraft.yungsapi:YungsApi-NeoForge")).using(project(":NeoForge"))
            substitute(module("com.yungnickyoung.minecraft.yungsapi:YungsApi-Fabric")).using(project(":Fabric"))
            substitute(module("com.yungnickyoung.minecraft.yungsapi:YungsApi-Common")).using(project(":Common"))
        }
    }
}
```

This also fixes the "compatible versions" list to support 26.1 - 26.1.2.
Additionally, this removes capabilities from the outgoing configurations, instead simply using loader attributes like how Jared's multiloader template behaves. Otherwise, the dependency substitution would've been unusable in development environments.