### PR TITLE
Fix custom banner names and overhaul custom banners to make them closer to Ominous Banners

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/world/banner/Banner.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/yungsapi/world/banner/Banner.java
@@ -1,17 +1,22 @@
 package com.yungnickyoung.minecraft.yungsapi.world.banner;
 
+import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.item.Rarity;
+import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.WallBannerBlock;
 import net.minecraft.world.level.block.entity.BannerPattern;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -83,8 +88,11 @@ public class Banner {
     public static class Builder {
         private final List<ColoredBannerPattern> patterns = new ArrayList<>();
         private String     customNameTranslate;
+        private String     customNameFallback;
         private TextColor  customColor;
-        private BlockState state = Blocks.BLACK_WALL_BANNER.defaultBlockState();
+        private @Nullable Boolean    showPatternsInTooltip = null;
+        private @Nullable Rarity     rarity = null;
+        private           BlockState state  = Blocks.BLACK_WALL_BANNER.defaultBlockState();
 
         public Builder() {
         }
@@ -105,7 +113,23 @@ public class Banner {
         }
 
         public Builder customName(String translatableNamePath) {
+            return this.customName(translatableNamePath, null);
+        }
+
+        public Builder customName(String translatableNamePath, String fallback) {
             this.customNameTranslate = translatableNamePath;
+            this.customNameFallback = fallback;
+            if (this.showPatternsInTooltip == null) {
+                this.showPatternsInTooltip = false;
+            }
+            if (this.rarity == null) {
+                this.rarity = Rarity.UNCOMMON;
+            }
+            return this;
+        }
+
+        public Builder showPatternsInTooltip() {
+            this.showPatternsInTooltip = true;
             return this;
         }
 
@@ -116,6 +140,11 @@ public class Banner {
 
         public Builder customColor(TextColor textColor) {
             this.customColor = textColor;
+            return this;
+        }
+
+        public Builder rarity(Rarity rarity) {
+            this.rarity = rarity;
             return this;
         }
 
@@ -140,13 +169,23 @@ public class Banner {
                 patternList.add(patternNBT);
             });
 
+            var components = DataComponentMap.builder();
             // Custom name and color
-            if (this.customColor != null || this.customNameTranslate != null) {
-                var components = DataComponentMap.builder()
-                        .set(DataComponents.CUSTOM_NAME, Component.translatable(this.customNameTranslate).withStyle(s -> this.customColor == null ? s : s.withColor(this.customColor)))
-                        .build();
-                nbt.store("components", DataComponentMap.CODEC, components);
+            if (this.customNameTranslate != null) {
+                components.set(DataComponents.ITEM_NAME,
+                               Component.translatableWithFallback(this.customNameTranslate, this.customNameFallback)
+                                       .withStyle(s -> this.customColor == null ? s : s.withColor(this.customColor)));
             }
+            // Tooltip
+            if (this.showPatternsInTooltip != null && !this.showPatternsInTooltip) {
+                components.set(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.DEFAULT.withHidden(DataComponents.BANNER_PATTERNS, true));
+            }
+            // Rarity
+            if (this.rarity != null) {
+                components.set(DataComponents.RARITY, this.rarity);
+            }
+
+            nbt.store("components", DataComponentMap.CODEC, components.build());
 
             // Add tags to NBT
             nbt.put("patterns", patternList);


### PR DESCRIPTION
If a custom name is present, it is now set as the *item name* (rather than the *custom name*), like Ominous banners (this prevents the name from appearing in italics).

The custom name system now allows setting fallbacks, too. This means the translation key can be a properly-formatted key instead of also having to be the fallback for if the mod isn't loaded.

Also, if there's a custom name, the patterns will not be shown in the item tooltip and the item's rarity will be set to uncommon. These match the ominous banner.